### PR TITLE
Converting Seeds to Key

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ __pycache__/
 *.ngc
 *.gmm
 *.results
+build
+ngclearn.egg-info
+dist

--- a/ngclearn/engine/nodes/cells/LIFCell.py
+++ b/ngclearn/engine/nodes/cells/LIFCell.py
@@ -87,13 +87,13 @@ class LIFCell(Cell):  # inherits from Node class
 
         sign: scalar sign to multiply output signal by (DEFAULT: None)
 
-        seed: integer seed to control determinism of any underlying synapses
+        key: PRGN Key to control determinism of any underlying synapses
             associated with this cell
     """
     def __init__(self, name, n_units, dt, tau_m, v_thr_base, R_m=1., thr_jitter=0.1,
                  lat_Rinh=0., thr_mode='dthr', thr_gain=None, thr_decay=None,
-                 spk_mode='bool', sign=None, seed=69):
-        super().__init__(name, n_units, dt, seed)
+                 spk_mode='bool', sign=None, key=None):
+        super().__init__(name, n_units, dt, key)
         self.v_reset = -2. ## voltage value to set after action potential/spike
         self.v_min = -15. ## minimum voltage potential
 

--- a/ngclearn/engine/nodes/cells/WTASCell.py
+++ b/ngclearn/engine/nodes/cells/WTASCell.py
@@ -53,12 +53,12 @@ class WTASCell(Cell):  # inherits from Node class
 
         sign: scalar sign to multiply output signal by (DEFAULT: None)
 
-        seed: integer seed to control determinism of any underlying synapses
+        key: PRNG key to control determinism of any underlying synapses
             associated with this cell
     """
     def __init__(self, name, n_units, dt, v_thr_base, R_m=1., thr_gain=None,
-                 thr_jitter=0., sign=None, seed=69):
-        super().__init__(name, n_units, dt, seed)
+                 thr_jitter=0., sign=None, key=None):
+        super().__init__(name, n_units, dt, key)
         self.sign = 1. if sign is None else sign
         self.v_thr_base = v_thr_base
         self.thr_gain = 0. if thr_gain is None else thr_gain

--- a/ngclearn/engine/nodes/cells/cell.py
+++ b/ngclearn/engine/nodes/cells/cell.py
@@ -13,11 +13,11 @@ class Cell(Node, ABC):
 
         dt: integration time constant
 
-        seed: integer seed to control determinism of any underlying synapses
+        key: PRNG key to control determinism of any underlying synapses
             associated with this cell
     """
-    def __init__(self, name, n_units, dt, seed=69):
-        super().__init__(name=name, dt=dt, seed=seed)
+    def __init__(self, name, n_units, dt, key=None):
+        super().__init__(name=name, dt=dt, key=key)
         self.n_units = n_units
 
     def set_to_rest(self, batch_size=1, hard=True):

--- a/ngclearn/engine/nodes/cells/errCell.py
+++ b/ngclearn/engine/nodes/cells/errCell.py
@@ -12,11 +12,11 @@ class ErrCell(Cell):  # inherits from Node class
 
         dt: integration time constant
 
-        seed: integer seed to control determinism of any underlying synapses
+        key: PRNG Key to control determinism of any underlying synapses
             associated with this cell
     """
-    def __init__(self, name, n_units, dt, seed=69):
-        super().__init__(name, n_units, dt, seed)
+    def __init__(self, name, n_units, dt, key=None):
+        super().__init__(name, n_units, dt, key)
         # cell compartments
         self.comp["err"] = None
         self.comp["targ"] = None

--- a/ngclearn/engine/nodes/cells/latencyCell.py
+++ b/ngclearn/engine/nodes/cells/latencyCell.py
@@ -17,11 +17,11 @@ class LatencyCell(Cell):  # inherits from Node class
 
         thr:
 
-        seed: integer seed to control determinism of any underlying synapses
+        key: PRNG Key to control determinism of any underlying synapses
             associated with this cell
     """
-    def __init__(self, name, n_units, dt, tau=5., thr=0.01, seed=69):
-        super().__init__(name, n_units, dt, seed)
+    def __init__(self, name, n_units, dt, tau=5., thr=0.01, key=None):
+        super().__init__(name, n_units, dt, key)
         self.tau = tau
         self.thr = thr
         self.linearize = False

--- a/ngclearn/engine/nodes/cells/passCell.py
+++ b/ngclearn/engine/nodes/cells/passCell.py
@@ -12,11 +12,11 @@ class PassCell(Cell):  # inherits from Node class
 
         dt: integration time constant
 
-        seed: integer seed to control determinism of any underlying synapses
+        key: PRNG key to control determinism of any underlying synapses
             associated with this cell
     """
-    def __init__(self, name, n_units, dt, seed=69):
-        super().__init__(name, n_units, dt, seed)
+    def __init__(self, name, n_units, dt, key=None):
+        super().__init__(name, n_units, dt, key)
         # cell compartments
         self.comp["in"] = None
 

--- a/ngclearn/engine/nodes/cells/poissCell.py
+++ b/ngclearn/engine/nodes/cells/poissCell.py
@@ -18,11 +18,11 @@ class PoissCell(Cell):  # inherits from Node class
         max_lag: lag coefficent; maximum time allowed to pass before first spike emitted
             (DEFAULT: 0)
 
-        seed: integer seed to control determinism of any underlying synapses
+        key: PRNG key to control determinism of any underlying synapses
             associated with this cell
     """
-    def __init__(self, name, n_units, dt, max_lag=0., seed=69):
-        super().__init__(name, n_units, dt, seed)
+    def __init__(self, name, n_units, dt, max_lag=0., key=None):
+        super().__init__(name, n_units, dt, key)
         self.max_lag = max_lag ## max time allowed to pass before first spike emitted
 
         if max_lag > 0.: ## compute lags if max_lag is > 0

--- a/ngclearn/engine/nodes/cells/quadLIFCell.py
+++ b/ngclearn/engine/nodes/cells/quadLIFCell.py
@@ -100,15 +100,15 @@ class QuadLIFCell(LIFCell):  # inherits from LIFCell class
 
         sign: scalar sign to multiply output signal by (DEFAULT: None)
 
-        seed: integer seed to control determinism of any underlying synapses
+        key: PRNG key to control determinism of any underlying synapses
             associated with this cell
     """
     def __init__(self, name, n_units, dt, tau_m, v_thr_base, R_m=1., thr_jitter=0.1,
                  a0=1., v_c=0.2, lat_Rinh=0., thr_mode='dthr', thr_gain=None,
-                 thr_decay=None, spk_mode='bool', sign=None, seed=69):
+                 thr_decay=None, spk_mode='bool', sign=None, key=None):
         super().__init__(name, n_units, dt, tau_m, v_thr_base, R_m, thr_jitter,
                          lat_Rinh, thr_mode, thr_gain, thr_decay, spk_mode, sign,
-                         seed)
+                         key)
         self.a0 = a0 #1. # scaling factor
         self.v_c = v_c # 0.2 or 0.8 # critical voltage
         #self.v_reset = -0.5

--- a/ngclearn/engine/nodes/ops/expKernel.py
+++ b/ngclearn/engine/nodes/ops/expKernel.py
@@ -33,11 +33,11 @@ class ExpKernel(Op):  # inherits from Node class
 
         nu: spike time interval for window (window time bound)
 
-        seed: integer seed to control determinism of any underlying synapses
+        key: PRNG Key to control determinism of any underlying synapses
             associated with this operator
     """
-    def __init__(self, name, n_units, dt, tau_w=500., nu=4., seed=69):
-        super().__init__(name, n_units, dt, seed)
+    def __init__(self, name, n_units, dt, tau_w=500., nu=4., key=None):
+        super().__init__(name, n_units, dt, key)
         self.tau_w = tau_w  # kernel time constant; (micro-sec, spike window time constant)
         self.nu = nu  # window time bound (in ms?)
         self.win_len = int(nu/dt) + 1 # window length

--- a/ngclearn/engine/nodes/ops/op.py
+++ b/ngclearn/engine/nodes/ops/op.py
@@ -13,11 +13,11 @@ class Op(Node, ABC):
 
         dt: integration time constant
 
-        seed: integer seed to control determinism of any underlying synapses
+        key: PRNG Key to control determinism of any underlying synapses
             associated with this operator
     """
-    def __init__(self, name, n_units, dt, seed=69):
-        super().__init__(name=name, dt=dt, seed=seed)
+    def __init__(self, name, n_units, dt, key=None):
+        super().__init__(name=name, dt=dt, key=key)
         self.n_units = n_units
 
     def set_to_rest(self, batch_size=1, hard=True):

--- a/ngclearn/engine/nodes/ops/scaleNode.py
+++ b/ngclearn/engine/nodes/ops/scaleNode.py
@@ -14,11 +14,11 @@ class ScaleNode(Op):  # inherits from Node class
 
         scale: scaling factor to apply to this node's output (compartment)
 
-        seed: integer seed to control determinism of any underlying synapses
+        key: PRNG Key to control determinism of any underlying synapses
             associated with this operator
     """
-    def __init__(self, name, n_units, dt, scale, seed=69):
-        super().__init__(name, n_units, dt, seed)
+    def __init__(self, name, n_units, dt, scale, key=None):
+        super().__init__(name, n_units, dt, key)
         self.scale = scale
 
     def step(self):

--- a/ngclearn/engine/nodes/ops/sumNode.py
+++ b/ngclearn/engine/nodes/ops/sumNode.py
@@ -14,11 +14,11 @@ class SumNode(Op):  # inherits from Op class
 
         dt: integration time constant
 
-        seed: integer seed to control determinism of any underlying synapses
+        key: PRNG Key to control determinism of any underlying synapses
             associated with this operator
     """
-    def __init__(self, name, n_units, dt, seed=69):
-        super().__init__(name, n_units, dt, seed)
+    def __init__(self, name, n_units, dt, key=None):
+        super().__init__(name, n_units, dt, key)
         self.add_bundle_rule('input', additive(self))
 
     def pre_gather(self):

--- a/ngclearn/engine/nodes/ops/trinarySplitNode.py
+++ b/ngclearn/engine/nodes/ops/trinarySplitNode.py
@@ -23,11 +23,11 @@ class TrinarySplitNode(Op):
 
         dt: integration time constant
 
-        seed: integer seed to control determinism of any underlying synapses
+        key: PRNG Key to control determinism of any underlying synapses
             associated with this operator
     """
-    def __init__(self, name, n_units, dt, seed=69):
-        super().__init__(name, n_units, dt, seed)
+    def __init__(self, name, n_units, dt, key=None):
+        super().__init__(name, n_units, dt, key)
 
         # cell compartments
         self.comp["in"] = None

--- a/ngclearn/engine/nodes/ops/varTrace.py
+++ b/ngclearn/engine/nodes/ops/varTrace.py
@@ -52,12 +52,12 @@ class VarTrace(Op):  # inherits from Node class
                 "exp" = exponential trace filter
                 "step" = step trace filter
 
-        seed: integer seed to control determinism of any underlying synapses
+        key: PRNG Key to control determinism of any underlying synapses
             associated with this operator
     """
     def __init__(self, name, n_units, dt, tau_tr=50., incr_pos=False,
-                 a_delta=1., decay_type="lin", seed=69):
-        super().__init__(name, n_units, dt, seed)
+                 a_delta=1., decay_type="lin", key=None):
+        super().__init__(name, n_units, dt, key)
         self.tau_tr = tau_tr  ## trace time constant
         self.incr_pos = incr_pos ## increment trace +1 instead of set to 1 if spike
         self.a_delta = a_delta ## if incr_pos == True, increase ODE by this value

--- a/ngclearn/engine/nodes/synapses/evSTDPSynapse.py
+++ b/ngclearn/engine/nodes/synapses/evSTDPSynapse.py
@@ -46,12 +46,12 @@ class EvSTDPSynapse(Synapse):  # inherits from Node class
 
         sign: scalar sign to multiply output signal by (DEFAULT: 1)
 
-        seed: integer seed to control determinism of any underlying synapses
+        key: PRNG Key to control determinism of any underlying synapses
             associated with this cable
     """
     def __init__(self, name, dt, shape, lamb, eta, w_norm=None,
-                 sign=None, seed=69):
-        super().__init__(name=name, shape=shape, dt=dt, seed=seed)
+                 sign=None, key=None):
+        super().__init__(name=name, shape=shape, dt=dt, key=key)
         self.eta = eta
         self.lamb = lamb
         self.sign = 1 if sign is None else sign
@@ -64,7 +64,6 @@ class EvSTDPSynapse(Synapse):  # inherits from Node class
         self.comp["post"] = None
 
         # preprocessing - set up synaptic efficacy matrix
-        self.key = random.PRNGKey(seed)
         self.key, *subkeys = random.split(self.key, 2)
         lb = 0.025 # 0.25
         ub = 0.8 #1. #0.5 # 0.75

--- a/ngclearn/engine/nodes/synapses/hebbianSynapse.py
+++ b/ngclearn/engine/nodes/synapses/hebbianSynapse.py
@@ -47,8 +47,8 @@ class HebbianSynapse(Synapse):  # inherits from Cell class
         seed: integer seed to control determinism of any underlying synapses
             associated with this cable
     """
-    def __init__(self, name, dt, shape, eta, sign=None, seed=69):
-        super().__init__(name=name, shape=shape, dt=dt, seed=seed)
+    def __init__(self, name, dt, shape, eta, sign=None, key=None):
+        super().__init__(name=name, shape=shape, dt=dt, key=key)
         self.shape = shape  # shape of synaptic matrix W
         self.sign = 1 if sign is None else sign
         self.eta = eta ## step size
@@ -58,7 +58,6 @@ class HebbianSynapse(Synapse):  # inherits from Cell class
         self.comp["in"] = None
 
         #Preprocessing
-        self.key = random.PRNGKey(seed)
         self.key, *subkeys = random.split(self.key, 2)
         sigma = 0.025
         self.W = random.normal(subkeys[0], self.shape, dtype=jnp.float32) * sigma

--- a/ngclearn/engine/nodes/synapses/projectionSynapse.py
+++ b/ngclearn/engine/nodes/synapses/projectionSynapse.py
@@ -22,11 +22,11 @@ class ProjectionSynapse(Synapse):  # inherits from Cell class
 
         sign: scalar sign to multiply output signal by (DEFAULT: 1)
 
-        seed: integer seed to control determinism of any underlying synapses
+        key: PRNG Key to control determinism of any underlying synapses
             associated with this cable
     """
-    def __init__(self, name, dt, shape, sign=None, seed=69):
-        super().__init__(name=name, shape=shape, dt=dt, seed=seed)
+    def __init__(self, name, dt, shape, sign=None, key=None):
+        super().__init__(name=name, shape=shape, dt=dt, key=key)
         self.shape = shape  # shape of synaptic matrix W
         self.sign = 1 if sign is None else sign
 
@@ -34,7 +34,6 @@ class ProjectionSynapse(Synapse):  # inherits from Cell class
         self.comp["in"] = None
 
         #Preprocessing
-        self.key = random.PRNGKey(seed)
         self.key, *subkeys = random.split(self.key, 2)
         sigma = 0.025
         self.W = random.normal(subkeys[0], self.shape, dtype=jnp.float32) * sigma

--- a/ngclearn/engine/nodes/synapses/rSTDPSynapse.py
+++ b/ngclearn/engine/nodes/synapses/rSTDPSynapse.py
@@ -105,14 +105,14 @@ class RSTDPSynapse(Synapse):  # inherits from Node class
 
         sign: scalar sign to multiply output signal by (DEFAULT: 1)
 
-        seed: integer seed to control determinism of any underlying synapses
+        key: PRNG Key to control determinism of any underlying synapses
             associated with this cable
     """
     def __init__(self, name, dt, shape, eta, tau_e=100., tau_w=1000.,
                  x_tar=0.0, use_td_error=True, reset_Elg_on_reward=True,
                  Aplus=1., Aminus=0., exp_beta=None, w_norm=None, push_rate=-1,
-                 push_amount=0., sign=None, seed=69):
-        super().__init__(name=name, shape=shape, dt=dt, seed=seed)
+                 push_amount=0., sign=None, key=None):
+        super().__init__(name=name, shape=shape, dt=dt, key=key)
         self.eta = eta
         # STDP meta-parameters
         self.x_tar = x_tar
@@ -145,7 +145,6 @@ class RSTDPSynapse(Synapse):  # inherits from Node class
         self.comp['EgMask'] = None
 
         # preprocessing - set up synaptic efficacy matrix
-        self.key = random.PRNGKey(seed)
         self.key, *subkeys = random.split(self.key, 2)
         lb = 0.025 # 0.25
         ub = 0.55 #0.8

--- a/ngclearn/engine/nodes/synapses/synapse.py
+++ b/ngclearn/engine/nodes/synapses/synapse.py
@@ -15,11 +15,11 @@ class Synapse(Node, ABC):
 
         dt: integration time constant
 
-        seed: integer seed to control determinism of any underlying synapses
+        key: PRNG Key to control determinism of any underlying synapses
             associated with this cable
     """
-    def __init__(self, name, shape, dt, seed=69):
-        super().__init__(name=name, dt=dt, seed=seed)
+    def __init__(self, name, shape, dt, key=None):
+        super().__init__(name=name, dt=dt, key=key)
         self.shape = shape
 
     def evolve(self):

--- a/ngclearn/engine/nodes/synapses/trSTDPSynapse.py
+++ b/ngclearn/engine/nodes/synapses/trSTDPSynapse.py
@@ -100,12 +100,12 @@ class TrSTDPSynapse(Synapse):  # inherits from Node class
 
         sign: scalar sign to multiply output signal by (DEFAULT: 1)
 
-        seed: integer seed to control determinism of any underlying synapses
+        key: PRNG Key to control determinism of any underlying synapses
             associated with this cable
     """
     def __init__(self, name, dt, shape, eta, mu=1., exp_beta=None,
-                 x_tar=0.7, Aplus=1., Aminus=0., w_norm=None, sign=None, seed=69):
-        super().__init__(name=name, shape=shape, dt=dt, seed=seed)
+                 x_tar=0.7, Aplus=1., Aminus=0., w_norm=None, sign=None, key=None):
+        super().__init__(name=name, shape=shape, dt=dt, key=key)
         self.eta = eta
         self.mu = mu ## power to raise STDP adjustment by
         self.exp_beta = exp_beta ## if not None, will trigger exp-depend STPD rule


### PR DESCRIPTION
In the current version of the code, if a model is saved it will store the seed that was used to initialize it. This means that the random state is reset back to its initial state every time it is saved and loaded. Changing the stored value from the seed to the PRNG key will prevent this problem as the current random state can be stored and loaded on demand.